### PR TITLE
7 fix display set rotation

### DIFF
--- a/drivers/display/ilitek/ili9163c/ili9163c.c
+++ b/drivers/display/ilitek/ili9163c/ili9163c.c
@@ -180,26 +180,14 @@ static int ili9163c_set_orientation(const struct device *dev,
 
 	int r;
 	uint8_t tx_data = ILI9163C_MADCTL_BGR;
-	if (config->quirks->cmd_set == CMD_SET_1) {
-		if (orientation == DISPLAY_ORIENTATION_NORMAL) {
-			tx_data |= ILI9163C_MADCTL_MX;
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_90) {
-			tx_data |= ILI9163C_MADCTL_MV;
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_180) {
-			tx_data |= ILI9163C_MADCTL_MY;
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_270) {
-			tx_data |= ILI9163C_MADCTL_MV | ILI9163C_MADCTL_MX | ILI9163C_MADCTL_MY;
-		}
-	} else if (config->quirks->cmd_set == CMD_SET_2) {
-		if (orientation == DISPLAY_ORIENTATION_NORMAL) {
-			/* Do nothing */
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_90) {
-			tx_data |= ILI9163C_MADCTL_MV | ILI9163C_MADCTL_MY;
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_180) {
-			tx_data |= ILI9163C_MADCTL_MY | ILI9163C_MADCTL_MX;
-		} else if (orientation == DISPLAY_ORIENTATION_ROTATED_270) {
-			tx_data |= ILI9163C_MADCTL_MV | ILI9163C_MADCTL_MX;
-		}
+	if (orientation == DISPLAY_ORIENTATION_NORMAL) {
+		/* Do nothing */
+	} else if (orientation == DISPLAY_ORIENTATION_ROTATED_90) {
+		tx_data |= ILI9163C_MADCTL_MV | ILI9163C_MADCTL_MX;
+	} else if (orientation == DISPLAY_ORIENTATION_ROTATED_180) {
+		tx_data |= ILI9163C_MADCTL_MX | ILI9163C_MADCTL_MY;
+	} else if (orientation == DISPLAY_ORIENTATION_ROTATED_270) {
+		tx_data |= ILI9163C_MADCTL_MV | ILI9163C_MADCTL_MY;
 	}
 
 	r = ili9163c_transmit(dev, ILI9163C_MADCTL, &tx_data, 1U);

--- a/drivers/display/ilitek/ili9163c/ili9163c.c
+++ b/drivers/display/ilitek/ili9163c/ili9163c.c
@@ -175,7 +175,6 @@ static int ili9163c_set_pixel_format(const struct device *dev,
 static int ili9163c_set_orientation(const struct device *dev,
 				    const enum display_orientation orientation)
 {
-	const struct ili9163c_config *config = dev->config;
 	struct ili9163c_data *data = dev->data;
 
 	int r;
@@ -408,17 +407,12 @@ static const struct display_driver_api ili9163c_api = {
 	.set_orientation = ili9163c_set_orientation,
 };
 
-static const struct ili9163c_quirks ili9163c_quirks = {
-	.cmd_set = CMD_SET_1,
-};
-
 #define INST_DT_ILI9163C(n) DT_INST(n, ilitek_ili9163c)
 
 #define ILI9163C_INIT(n)                                                                           \
 	ILI9163C_REGS_INIT(n);                                                                     \
                                                                                                    \
 	static const struct ili9163c_config ili9163c_config_##n = {                                \
-		.quirks = &ili9163c_quirks,                                                        \
 		.mipi_dev = DEVICE_DT_GET(DT_PARENT(DT_INST(n, DT_DRV_COMPAT))),                   \
 		.dbi_config =                                                                      \
 			{                                                                          \

--- a/drivers/display/ilitek/ili9163c/ili9163c.c
+++ b/drivers/display/ilitek/ili9163c/ili9163c.c
@@ -243,6 +243,11 @@ static int ili9163c_configure(const struct device *dev)
 	enum display_pixel_format pixel_format;
 	enum display_orientation orientation;
 
+	r = config->regs_init_fn(dev);
+	if (r < 0) {
+		return r;
+	}
+
 	if (config->pixel_format == ILI9163C_PIXEL_FORMAT_RGB565) {
 		pixel_format = PIXEL_FORMAT_RGB_565;
 	} else {
@@ -274,11 +279,6 @@ static int ili9163c_configure(const struct device *dev)
 		if (r < 0) {
 			return r;
 		}
-	}
-
-	r = config->regs_init_fn(dev);
-	if (r < 0) {
-		return r;
 	}
 
 	return 0;

--- a/drivers/display/ilitek/ili9163c/ili9163c.h
+++ b/drivers/display/ilitek/ili9163c/ili9163c.h
@@ -70,11 +70,6 @@
 #define ILI9163C_GAMADJ_LEN   1U
 #define ILI9163C_MADCTL_LEN   1U
 
-/** SCREEN X resolution (pixels). */
-#define ILI9163C_X_RES 128U
-/** SCREEN Y resolution (pixels). */
-#define ILI9163C_Y_RES 160U
-
 /** Command/data GPIO level for commands. */
 #define ILI9163C_CMD  1U
 /** Command/data GPIO level for data. */
@@ -89,17 +84,7 @@
 /** Reset wait time (ms), ref 15.4 of ILI9163C manual. */
 #define ILI9163C_RESET_WAIT_TIME 5
 
-enum madctl_cmd_set {
-	CMD_SET_1,
-	CMD_SET_2,
-};
-
-struct ili9163c_quirks {
-	enum madctl_cmd_set cmd_set;
-};
-
 struct ili9163c_config {
-	const struct ili9163c_quirks *quirks;
 	const struct device *mipi_dev;
 	struct mipi_dbi_config dbi_config;
 	uint8_t pixel_format;


### PR DESCRIPTION
Reworked MADCTL command to setup lcd in the right state.